### PR TITLE
change how private SLF4J dependency is declared so it won't appear in modules file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,4 +58,6 @@ Sometimes a gap in coverage is unavoidable, usually because the compiler require
 
 ## Note on dependencies
 
-This project's `build.gradle` contains special logic to exclude dependencies from `pom.xml`. This is because it is meant to be used as part of one of the LaunchDarkly SDKs, and the different SDKs have different strategies for either exposing or embedding these dependencies. Therefore, it is the responsibility of each SDK to provide its own dependency for any module that is actually required in order for `com.launchdarkly.logging` to work.
+This project includes an optional integration with SLF4J-- but we do not want to declare SLF4J as a runtime dependency, because we do not want to require applications to pull in SLF4J if they're not actually using it (see documentation comments in `LDSLF4J.java`). Therefore, our Gradle configuration declares the SLF4J dependency in a separate compile-time configuration that will not be included in the `.pom` or `.module` files when we publish the package.
+
+In general, we should avoid declaring any runtime dependencies at all. This project is intended to be very lightweight, which is especially important since it can be used in Android. For instance, as convenient as Guava can be, we should not use Guava at all (except possibly in _test_ code) because it is a large library-- and also because if the application does use Guava, we don't want to have to worry about conflicting with whatever version they're using.

--- a/build-android.gradle
+++ b/build-android.gradle
@@ -69,3 +69,11 @@ dependencies {
         exclude group: "com.squareup.okhttp3" // also unused, causes dex limit to be exceeded
     }
 }
+
+compile {
+    classpath = configurations.privateImplementation // see build-shared.gradle
+}
+
+androidTestCompile {
+    classpath = configurations.privateImplementation // see build-shared.gradle
+}

--- a/build-android.gradle
+++ b/build-android.gradle
@@ -59,6 +59,11 @@ android {
 }
 
 dependencies {
+    // See build-shared-gradle regarding the purpose of "privateImplementation" - in the
+    // Android build this is not an issue, because we're not building for release, we
+    // just want to run tests.
+    configurations.privateImplementation.dependencies.each { implementation(it) }
+
     androidTestImplementation "junit:junit:4.12"
     androidTestImplementation "org.hamcrest:hamcrest-library:1.3"
     androidTestImplementation "uk.org.lidalia:slf4j-test:1.1.0"
@@ -68,12 +73,4 @@ dependencies {
         exclude group: "org.eclipse.jetty" // we don't use the HTTP helpers and they don't work in Android
         exclude group: "com.squareup.okhttp3" // also unused, causes dex limit to be exceeded
     }
-}
-
-compile {
-    classpath = configurations.privateImplementation // see build-shared.gradle
-}
-
-androidTestCompile {
-    classpath = configurations.privateImplementation // see build-shared.gradle
 }

--- a/build-shared.gradle
+++ b/build-shared.gradle
@@ -23,7 +23,7 @@ ext.libraries = [:]
 
 configurations {
     // The dependencies in privateImplementation will not be exposed in pom.xml or our
-    // module file.
+    // module file. See build.gradle and build-android.gradle for how this is used.
     privateImplementation.extendsFrom implementation
 }
 
@@ -36,12 +36,4 @@ dependencies {
     testImplementation("com.launchdarkly:test-helpers:1.1.0") {
         exclude group: "org.hamcrest"
     }
-}
-
-compileJava {
-    classpath = configurations.privateImplementation
-}
-
-javadoc {
-    classpath = configurations.privateImplementation
 }

--- a/build-shared.gradle
+++ b/build-shared.gradle
@@ -21,9 +21,14 @@ ext.versions = [
 
 ext.libraries = [:]
 
+configurations {
+    // The dependencies in privateImplementation will not be exposed in pom.xml or our
+    // module file.
+    privateImplementation.extendsFrom implementation
+}
+
 dependencies {
-    // Dependencies will not be exposed in the pom - see pom.withXml block in build.gradle
-    implementation "org.slf4j:slf4j-api:${versions.slf4j}"
+    privateImplementation "org.slf4j:slf4j-api:${versions.slf4j}"
 
     testImplementation "org.hamcrest:hamcrest-library:1.3"
     testImplementation "junit:junit:4.12"
@@ -31,4 +36,12 @@ dependencies {
     testImplementation("com.launchdarkly:test-helpers:1.1.0") {
         exclude group: "org.hamcrest"
     }
+}
+
+compileJava {
+    classpath = configurations.privateImplementation
+}
+
+javadoc {
+    classpath = configurations.privateImplementation
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ checkstyle {
     configFile file("${project.rootDir}/checkstyle.xml")
 }
 
+compileJava {
+    classpath = configurations.privateImplementation
+}
+
 // custom tasks for creating source/javadoc jars
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
@@ -48,6 +52,8 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 javadoc {
+    classpath = configurations.privateImplementation // see build-shared.gradle
+
     // Force the Javadoc build to fail if there are any Javadoc warnings. See: https://discuss.gradle.org/t/javadoc-fail-on-warning/18141/3
     // See JDK-8200363 (https://bugs.openjdk.java.net/browse/JDK-8200363)
     // for information about the -Xwerror option.

--- a/build.gradle
+++ b/build.gradle
@@ -155,13 +155,6 @@ publishing {
                     developerConnection = 'scm:git:ssh:git@github.com:launchdarkly/java-logging.git'
                     url = 'https://github.com/launchdarkly/java-logging'
                 }
-            }   
-                     
-            // We are deliberately hiding our dependencies in the pom. This allows the package
-            // to provide classes like LDSLF4J that can be used *if* the caller has SLF4J in
-            // the classpath, but without causing SLF4J to be pulled in by default.
-            pom.withXml {
-                asNode().dependencies.forEach { it.value = "" }
             }
         }
     }


### PR DESCRIPTION
This project includes an optional integration with SLF4J-- but we do not want to declare SLF4J as a runtime dependency, because we do not want to require applications to pull in SLF4J if they're not actually using it (see documentation comments in [`LDSLF4J.java`](https://github.com/launchdarkly/java-logging/blob/main/src/main/java/com/launchdarkly/logging/LDSLF4J.java)). Just declaring the dependency as `implementation` rather than `api` in Gradle is not enough to fully exclude it from published dependencies. As a result, if you build the Java SDK against this version, it still ends up having references to SLF4J in the build products... which is OK for now since the latest 5.x release of the SDK still does use SLF4J by default,  but we will want to remove that in 6.0.0.

My workaround for this, borrowed from another project, was a hacky customization that deleted the dependency out of the `.pom` during publication; however, I forgot that these days a `.module` file is also published alongside the `.pom`, and it was still showing SLF4J there. This PR fixes that by doing what I should've done in the first place: make up a separate dependency set, which I'm calling `privateImplementation`, that is inserted into the classpath in the build but does not affect the package's published dependencies at all.

I think we can release this change as a 1.1.1 patch; it is just fixing `.module` to correspond to what is in `.pom`.